### PR TITLE
ExemplaarIDs worden correct weergegeven in frontend

### DIFF
--- a/backend/src/main/java/com/WT/LibraryApp/Exemplaar/ExemplaarController.java
+++ b/backend/src/main/java/com/WT/LibraryApp/Exemplaar/ExemplaarController.java
@@ -18,6 +18,7 @@ import com.WT.LibraryApp.Boek.Boek;
 import com.WT.LibraryApp.Boek.BoekService;
 import com.WT.LibraryApp.Reservering.Reservering;
 import com.WT.LibraryApp.Reservering.ReserveringService;
+import com.WT.LibraryApp.Uitlening.UitleningService;
 
 @RestController
 @CrossOrigin(maxAge = 3600)
@@ -31,17 +32,30 @@ public class ExemplaarController {
 
 	@Autowired
 	private ReserveringService serviceReservering;
+	
+	@Autowired
+	private UitleningService serviceUitlening;
 
 	// Optie voor vragen naar alle exemplaren van een bepaald boek
 	@RequestMapping(value = "/boekexemplaren/{boekid}" /* TODO */) 
 	public Map<String, Object> vindBoekExemplaren(@PathVariable int boekid) {
 		
 		Map<String, Object> mapexemplaren = new HashMap<>();
-		mapexemplaren.put("Exemplaren", service.vindBoekExemplaren(boekid));
+		List<ExemplaarStatus> exemplarenstatus = new ArrayList<ExemplaarStatus>();
+		List<Exemplaar> exemplaren = service.vindBoekExemplaren(boekid);
+
 		// Kan ook gewoon in frontend worden gedaan
 		mapexemplaren.put("Hoeveelheid", (Integer) service.countByBoekId(boekid));
 		// Placeholder voor status uitlenen
-		mapexemplaren.put("Status", (Boolean) true);
+		for (Exemplaar exemplaar: exemplaren) {			
+			if (serviceUitlening.vindExemplaar(exemplaar.getId()).isPresent()) {
+				exemplarenstatus.add(new ExemplaarStatus(true, exemplaar));
+			} else {
+				exemplarenstatus.add(new ExemplaarStatus(false, exemplaar));
+			}
+			
+		}
+		mapexemplaren.put("ExemplarenStatus", exemplarenstatus);
 		return mapexemplaren;
 	}
 
@@ -90,10 +104,8 @@ public class ExemplaarController {
 		for (int i = 0; i < hoeveelheid; i++) {
 			tmpexemplaar = new Exemplaar();
 			tmpexemplaar.setBoekId(exemplaar.getBoekId());
-			tmpexemplaar.setReserveringId(exemplaar.getReserveringId());			
-			System.out.println(service.bepaalIndividueelId(exemplaar.getBoekId(), gebruikteIds));			
+			tmpexemplaar.setReserveringId(exemplaar.getReserveringId());					
 			gebruikteIds.add(service.bepaalIndividueelId(exemplaar.getBoekId(), gebruikteIds));
-			System.out.println(gebruikteIds);
 			tmpexemplaar.setIndividueelId(gebruikteIds.get(i));
 			service.opslaanExemplaar(tmpexemplaar);
 		}
@@ -101,3 +113,6 @@ public class ExemplaarController {
 	}
 
 }
+
+
+

--- a/backend/src/main/java/com/WT/LibraryApp/Exemplaar/ExemplaarController.java
+++ b/backend/src/main/java/com/WT/LibraryApp/Exemplaar/ExemplaarController.java
@@ -81,7 +81,7 @@ public class ExemplaarController {
 
 	// Optie voor toevoegen van reservatie5
 	@RequestMapping(method = RequestMethod.POST, value = "/opslaanexemplaar/{hoeveelheid}" /* TODO */)
-	public int opslaanExemplaar(@RequestBody Exemplaar exemplaar, @PathVariable int hoeveelheid) {
+	public List<Integer> opslaanExemplaar(@RequestBody Exemplaar exemplaar, @PathVariable int hoeveelheid) {
 
 		// Een temporary object wordt gebruikt omdat Hibernate(SQL) eenzelfde kopie van
 		// een exemplaar niet leuk vind.
@@ -90,14 +90,12 @@ public class ExemplaarController {
 		for (int i = 0; i < hoeveelheid; i++) {
 			tmpexemplaar = new Exemplaar();
 			tmpexemplaar.setBoekId(exemplaar.getBoekId());
-			tmpexemplaar.setReserveringId(exemplaar.getReserveringId());			
-			System.out.println(service.bepaalIndividueelId(exemplaar.getBoekId(), gebruikteIds));			
+			tmpexemplaar.setReserveringId(exemplaar.getReserveringId());						
 			gebruikteIds.add(service.bepaalIndividueelId(exemplaar.getBoekId(), gebruikteIds));
-			System.out.println(gebruikteIds);
 			tmpexemplaar.setIndividueelId(gebruikteIds.get(i));
 			service.opslaanExemplaar(tmpexemplaar);
 		}
-		return service.countByBoekId(exemplaar.getBoekId());
+		return gebruikteIds;
 	}
 
 }

--- a/backend/src/main/java/com/WT/LibraryApp/Exemplaar/ExemplaarStatus.java
+++ b/backend/src/main/java/com/WT/LibraryApp/Exemplaar/ExemplaarStatus.java
@@ -1,0 +1,32 @@
+package com.WT.LibraryApp.Exemplaar;
+
+public class ExemplaarStatus{
+	
+	private boolean status;
+	private Exemplaar exemplaar;
+	
+	public ExemplaarStatus(boolean status, Exemplaar exemplaar) {
+		super();
+		this.status = status;
+		this.exemplaar = exemplaar;
+	}
+
+	public boolean isStatus() {
+		return status;
+	}
+
+	public void setStatus(boolean status) {
+		this.status = status;
+	}
+
+	public Exemplaar getExemplaar() {
+		return exemplaar;
+	}
+
+	public void setExemplaar(Exemplaar exemplaar) {
+		this.exemplaar = exemplaar;
+	}
+	
+	
+	
+}

--- a/backend/src/main/java/com/WT/LibraryApp/Uitlening/IUitleningRepository.java
+++ b/backend/src/main/java/com/WT/LibraryApp/Uitlening/IUitleningRepository.java
@@ -1,7 +1,9 @@
 package com.WT.LibraryApp.Uitlening;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface IUitleningRepository extends JpaRepository<Uitlening, Integer>{
-
+	Optional<Uitlening> findByExemplaarId(int exemplaarId);
 }

--- a/backend/src/main/java/com/WT/LibraryApp/Uitlening/UitleningController.java
+++ b/backend/src/main/java/com/WT/LibraryApp/Uitlening/UitleningController.java
@@ -24,6 +24,11 @@ public class UitleningController {
 		return service.vindEentje(mijnid);
 	}
 	
+//	@RequestMapping("/vindexemplaar/{exemplaarid}") // werkt nog niet
+//	public Uitlening vindExemplaar(@PathVariable int exemplaarid) {
+//		return service.vindExemplaar(exemplaarid);
+//	}
+//	
 	@RequestMapping(value = "/uitleningen") // werkt nog niet
 	public List<Uitlening> vind() {
 		return service.vindAlleUitleningen();

--- a/backend/src/main/java/com/WT/LibraryApp/Uitlening/UitleningService.java
+++ b/backend/src/main/java/com/WT/LibraryApp/Uitlening/UitleningService.java
@@ -24,5 +24,11 @@ public class UitleningService {
 	public Uitlening maakUitleningAan(Uitlening uitlening) {
 		return repository.save(uitlening);
 	}
+
+	public Optional<Uitlening> vindExemplaar(int exemplaarid) {
+		return repository.findByExemplaarId(exemplaarid);
+	}
+	
+	
 	
 }

--- a/frontend/src/ExemplaarInformatie.js
+++ b/frontend/src/ExemplaarInformatie.js
@@ -20,6 +20,18 @@ function ExemplaarInformatie(props) {
         setBoekId(e.target.value)
     }
 
+    const isUitgeleend = (b) => {
+        return (b ? "ja ":  "nee");
+    }
+
+    const hoeveelheidUitgeleend = (exemplaren) => {
+        let total = 0;
+        exemplaren.map(exemplaar => {
+            total += exemplaar.status;
+        });
+        return total;
+    }
+
 
     const haalExemplarenOp = () => {
         fetch("http://localhost:8080/boekexemplaren/" + boekId)
@@ -29,9 +41,8 @@ function ExemplaarInformatie(props) {
                     if (result.Hoeveelheid > 0) {
                     setIsLoaded(true);        
                     //Sorteer op individueel id          
-                    setExemplaren(result.Exemplaren.sort((e1, e2) => e1.individueelId > e2.individueelId)); 
+                    setExemplaren(result.ExemplarenStatus.sort((e1, e2) => e1.exemplaar.individueelId > e2.exemplaar.individueelId)); 
                     setHoeveelExemplaren(result.Hoeveelheid);
-                    setStatusExemplaren(result.Status); //Wordt nog veranderd in de backend
                     setSuccesBericht('Gelukt!')
                     } else {
                         setSuccesBericht('Geen exemplaren van boek_id')
@@ -50,26 +61,23 @@ function ExemplaarInformatie(props) {
             <input type="number" defaultValue={1}
                                        onChange={e => setBoekId(e.target.value)}/>
             <button onClick={() => haalExemplarenOp()}>Haal Exemplaren Op</button>
+            <p>Van de {hoeveelexemplaren} boeken zijn er {hoeveelheidUitgeleend(exemplaren)} uitgeleend</p>
             <table>
                 <thead>
                     <tr>
                         <th>Label</th>
-                        <th>Status Lening</th>
-                        <th>Hoeveelheid</th>
+                        <th>Uitgeleend</th>
                     </tr>
                 </thead>
 
                 {exemplaren.map(exemplaar => (
                     <>
                         <tbody>
-                            <td key={exemplaar.id}>
-                                {"WT-" + boekId + "." + exemplaar.individueelId}
+                            <td key={exemplaar.exemplaar.id}>
+                                {"WT-" + boekId + "." + exemplaar.exemplaar.individueelId}
                             </td>
                             <td>
-                                {statusexemplaren.toString()}
-                            </td>
-                            <td>
-                                {hoeveelexemplaren}
+                                {isUitgeleend(exemplaar.status)}
                             </td>
                         </tbody>
                     </>

--- a/frontend/src/ExemplaarInformatie.js
+++ b/frontend/src/ExemplaarInformatie.js
@@ -8,10 +8,17 @@ function ExemplaarInformatie(props) {
     const [error, setError] = useState(null);
     const [isLoaded, setIsLoaded] = useState(false);
     const [exemplaren, setExemplaren] = useState([]);
-    const [hoeveelexemplaren, setHoeveelExemplaren] = useState();
+    const [hoeveelexemplaren, setHoeveelExemplaren] = useState(0);
     const [statusexemplaren, setStatusExemplaren] = useState([]);
     const [succesBericht, setSuccesBericht] = useState('');
     const [boekId, setBoekId] = useState(1);
+
+    const nieuwBoekId = (e) => {
+        setExemplaren([]);
+        setHoeveelExemplaren(0);
+        setStatusExemplaren([]);
+        setBoekId(e.target.value)
+    }
 
 
     const haalExemplarenOp = () => {
@@ -20,10 +27,11 @@ function ExemplaarInformatie(props) {
             .then(
                 (result) => {
                     if (result.Hoeveelheid > 0) {
-                    setIsLoaded(true);
-                    setExemplaren(result.Exemplaren);
+                    setIsLoaded(true);        
+                    //Sorteer op individueel id          
+                    setExemplaren(result.Exemplaren.sort((e1, e2) => e1.individueelId > e2.individueelId)); 
                     setHoeveelExemplaren(result.Hoeveelheid);
-                    setStatusExemplaren(result.Status);
+                    setStatusExemplaren(result.Status); //Wordt nog veranderd in de backend
                     setSuccesBericht('Gelukt!')
                     } else {
                         setSuccesBericht('Geen exemplaren van boek_id')
@@ -45,7 +53,7 @@ function ExemplaarInformatie(props) {
             <table>
                 <thead>
                     <tr>
-                        <th>Id</th>
+                        <th>Label</th>
                         <th>Status Lening</th>
                         <th>Hoeveelheid</th>
                     </tr>
@@ -55,7 +63,7 @@ function ExemplaarInformatie(props) {
                     <>
                         <tbody>
                             <td key={exemplaar.id}>
-                                {exemplaar.id}
+                                {"WT-" + boekId + "." + exemplaar.individueelId}
                             </td>
                             <td>
                                 {statusexemplaren.toString()}

--- a/frontend/src/ExemplaarInformatie.js
+++ b/frontend/src/ExemplaarInformatie.js
@@ -17,6 +17,7 @@ function ExemplaarInformatie(props) {
         setExemplaren([]);
         setHoeveelExemplaren(0);
         setStatusExemplaren([]);
+        setSuccesBericht('');
         setBoekId(e.target.value)
     }
 
@@ -58,8 +59,8 @@ function ExemplaarInformatie(props) {
 
     return (
         <div>
-            <input type="number" defaultValue={1}
-                                       onChange={e => setBoekId(e.target.value)}/>
+            <input type="number" defaultValue={1} min = {1}
+                                       onChange={nieuwBoekId}/>
             <button onClick={() => haalExemplarenOp()}>Haal Exemplaren Op</button>
             <p>Van de {hoeveelexemplaren} boeken zijn er {hoeveelheidUitgeleend(exemplaren)} uitgeleend</p>
             <table>

--- a/frontend/src/ExemplarenToevoegen.js
+++ b/frontend/src/ExemplarenToevoegen.js
@@ -14,11 +14,11 @@ function ExemplarenToevoegen(props) {
         setUit(true);
         voegExemplarenToe("http://localhost:8080/opslaanexemplaar/" + hoeveelheid, data).then(response => {
             if (response.ok) {
-                response.json().then(aantal => {
+                response.json().then(ids => {
                     let labels = [];
-                    for (let h = aantal - hoeveelheid; h < aantal; h++) {
-                        labels.push("WT-" + props.boekID + "." + (h + 1));
-                    }
+                    Array.from(ids, id=> {
+                        labels.push("WT-" + props.boekID + "." + id);
+                    })
                     setLabels(labels);
 
                 })


### PR DESCRIPTION
Deze PR is inclusief issue #43 van Huub. In de backend wordt er een nieuw object gemaakt waar het exemplaar en de status gecombineerd worden en als 1 object teruggestuurd kunnen worden, 